### PR TITLE
fix(content): update redis cache serialization issue

### DIFF
--- a/content-service/pom.xml
+++ b/content-service/pom.xml
@@ -106,6 +106,11 @@
       <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/content-service/src/main/java/org/protu/contentservice/common/config/RedisConfig.java
+++ b/content-service/src/main/java/org/protu/contentservice/common/config/RedisConfig.java
@@ -1,0 +1,82 @@
+package org.protu.contentservice.common.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  @Primary
+  public ObjectMapper objectMapper() {
+    return new ObjectMapper().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
+  @Bean(name = "redisObjectMapper")
+  @SuppressWarnings("deprecation")
+  public ObjectMapper redisObjectMapper() {
+    return new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .registerModule(new Jdk8Module())
+        .registerModule(new ParameterNamesModule())
+        .activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY
+        );
+  }
+
+  @Bean
+  public RedisCacheConfiguration cacheConfiguration(
+      @Qualifier("redisObjectMapper") ObjectMapper objectMapper) {
+    var serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+    return RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(Duration.ofMinutes(1))
+        .disableCachingNullValues()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair
+                .fromSerializer(new StringRedisSerializer())
+        )
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair
+                .fromSerializer(serializer)
+        );
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(
+      RedisConnectionFactory connectionFactory,
+      @Qualifier("redisObjectMapper") ObjectMapper redisMapper) {
+
+    var serializer = new Jackson2JsonRedisSerializer<>(redisMapper, Object.class);
+
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(serializer);
+    template.setHashKeySerializer(new StringRedisSerializer());
+    template.setHashValueSerializer(serializer);
+    template.setEnableTransactionSupport(true);
+    template.afterPropertiesSet();
+    return template;
+  }
+}

--- a/content-service/src/main/java/org/protu/contentservice/course/CourseController.java
+++ b/content-service/src/main/java/org/protu/contentservice/course/CourseController.java
@@ -5,7 +5,6 @@ import org.protu.contentservice.common.enums.SuccessMessage;
 import org.protu.contentservice.common.helpers.JwtHelper;
 import org.protu.contentservice.common.properties.AppProperties;
 import org.protu.contentservice.common.response.ApiResponse;
-import org.protu.contentservice.lesson.Lesson;
 import org.protu.contentservice.lesson.dto.LessonWithoutContent;
 import org.protu.contentservice.lesson.dto.LessonsWithCompletion;
 import org.springframework.http.HttpStatus;
@@ -46,7 +45,7 @@ public class CourseController {
   }
 
   @PostMapping
-  public ResponseEntity<ApiResponse<Course>> createCourse(
+  public ResponseEntity<ApiResponse<Void>> createCourse(
       @Validated @RequestBody CourseRequest courseRequest,
       HttpServletRequest request) {
 
@@ -66,7 +65,7 @@ public class CourseController {
   }
 
   @PatchMapping("/{courseName}")
-  public ResponseEntity<ApiResponse<Course>> updateCourse(
+  public ResponseEntity<ApiResponse<Void>> updateCourse(
       @PathVariable String courseName,
       @Validated @RequestBody CourseRequest courseRequest,
       HttpServletRequest request) {
@@ -84,7 +83,7 @@ public class CourseController {
   }
 
   @PostMapping("/{courseName}")
-  public ResponseEntity<ApiResponse<Course>> uploadCoursePic(
+  public ResponseEntity<ApiResponse<Void>> uploadCoursePic(
       @PathVariable String courseName,
       @RequestParam(name = "file") MultipartFile file,
       HttpServletRequest request) {
@@ -104,7 +103,7 @@ public class CourseController {
   }
 
   @PostMapping("/{courseName}/lessons/{lessonName}")
-  public ResponseEntity<ApiResponse<List<Lesson>>> addExistingLessonToCourse(
+  public ResponseEntity<ApiResponse<Void>> addExistingLessonToCourse(
       @PathVariable String courseName,
       @PathVariable String lessonName,
       HttpServletRequest request) {

--- a/content-service/src/main/java/org/protu/contentservice/lesson/LessonController.java
+++ b/content-service/src/main/java/org/protu/contentservice/lesson/LessonController.java
@@ -35,7 +35,7 @@ public class LessonController {
   }
 
   @PostMapping
-  public ResponseEntity<ApiResponse<Lesson>> createLesson(
+  public ResponseEntity<ApiResponse<Void>> createLesson(
       @Validated @RequestBody LessonRequest lessonRequest,
       HttpServletRequest request) {
 
@@ -55,7 +55,7 @@ public class LessonController {
   }
 
   @PatchMapping("/{lessonName}")
-  public ResponseEntity<ApiResponse<Lesson>> updateLesson(
+  public ResponseEntity<ApiResponse<Void>> updateLesson(
       @PathVariable String lessonName,
       @Validated @RequestBody LessonUpdateRequest lessonRequest,
       HttpServletRequest request) {

--- a/content-service/src/main/java/org/protu/contentservice/track/TrackController.java
+++ b/content-service/src/main/java/org/protu/contentservice/track/TrackController.java
@@ -45,7 +45,7 @@ public class TrackController {
   }
 
   @PostMapping
-  public ResponseEntity<ApiResponse<Track>> createTrack(
+  public ResponseEntity<ApiResponse<Void>> createTrack(
       @RequestBody @Validated TrackRequest trackRequest,
       HttpServletRequest request) {
 
@@ -55,7 +55,7 @@ public class TrackController {
   }
 
   @PatchMapping("/{trackName}")
-  public ResponseEntity<ApiResponse<Track>> updateTrack(
+  public ResponseEntity<ApiResponse<Void>> updateTrack(
       @PathVariable String trackName,
       @RequestBody @Validated TrackRequest trackRequest,
       HttpServletRequest request) {

--- a/content-service/src/main/java/org/protu/contentservice/track/TrackWithCourses.java
+++ b/content-service/src/main/java/org/protu/contentservice/track/TrackWithCourses.java
@@ -1,11 +1,9 @@
 package org.protu.contentservice.track;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.protu.contentservice.course.CourseDto;
 
 import java.util.List;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public record TrackWithCourses(
     Integer id,
     String name,

--- a/content-service/src/test/java/org/protu/contentservice/config/RedisContainerConfig.java
+++ b/content-service/src/test/java/org/protu/contentservice/config/RedisContainerConfig.java
@@ -1,26 +1,12 @@
 package org.protu.contentservice.config;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-
-import java.time.Duration;
 
 @TestConfiguration(proxyBeanMethods = false)
 @Testcontainers
@@ -34,55 +20,5 @@ public class RedisContainerConfig {
   @ServiceConnection
   RedisContainer redisContainerConnection() {
     return redisContainer;
-  }
-
-  @Bean
-  public ObjectMapper objectMapper() {
-    return new ObjectMapper()
-        .registerModule(new JavaTimeModule())
-        .registerModule(new Jdk8Module())
-        .registerModule(new ParameterNamesModule())
-        .activateDefaultTyping(
-            LaissezFaireSubTypeValidator.instance,
-            ObjectMapper.DefaultTyping.EVERYTHING,
-            JsonTypeInfo.As.PROPERTY
-        );
-  }
-
-  @Bean
-  public RedisCacheConfiguration cacheConfiguration(ObjectMapper objectMapper) {
-    GenericJackson2JsonRedisSerializer serializer =
-        new GenericJackson2JsonRedisSerializer(objectMapper);
-
-    return RedisCacheConfiguration.defaultCacheConfig()
-        .entryTtl(Duration.ofMinutes(60))
-        .disableCachingNullValues()
-        .serializeKeysWith(
-            RedisSerializationContext.SerializationPair
-                .fromSerializer(new StringRedisSerializer())
-        )
-        .serializeValuesWith(
-            RedisSerializationContext.SerializationPair
-                .fromSerializer(serializer)
-        );
-  }
-
-  @Bean
-  public RedisTemplate<String, Object> redisTemplate(
-      RedisConnectionFactory cf,
-      ObjectMapper objectMapper) {
-
-    GenericJackson2JsonRedisSerializer serializer =
-        new GenericJackson2JsonRedisSerializer(objectMapper);
-
-    RedisTemplate<String, Object> tpl = new RedisTemplate<>();
-    tpl.setConnectionFactory(cf);
-    tpl.setKeySerializer(new StringRedisSerializer());
-    tpl.setValueSerializer(serializer);
-    tpl.setHashKeySerializer(new StringRedisSerializer());
-    tpl.setHashValueSerializer(serializer);
-    tpl.setEnableTransactionSupport(true);
-    tpl.afterPropertiesSet();
-    return tpl;
   }
 }

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -118,6 +118,11 @@
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
       <version>4.2.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/user-service/src/main/resources/application.yaml
+++ b/user-service/src/main/resources/application.yaml
@@ -16,12 +16,10 @@ app:
       user-deleted: user.deleted
       user-pattern: user.*
 
-
-
 server.port: 8085
 
 logging.level:
-  org.springframework.security: TRACE
+  org.springframework.security: INFO
 
 spring:
   profiles:


### PR DESCRIPTION
- Add separate beans of ObjectMapper for http requests and Redis cache.
- Remove custom Redis configs in tests and used the main app configs instead.
- Add caffiene dependency and refactor controllers code.