### PR TITLE
feat(user): add admin user on startup and persist user events

### DIFF
--- a/user-service/src/main/java/org/protu/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/org/protu/userservice/UserServiceApplication.java
@@ -1,16 +1,65 @@
 package org.protu.userservice;
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import org.protu.userservice.config.AppProperties;
+import org.protu.userservice.dto.rabbitmq.RabbitMessage;
+import org.protu.userservice.dto.rabbitmq.UserData;
+import org.protu.userservice.model.User;
+import org.protu.userservice.producer.UserEventsProducer;
+import org.protu.userservice.repository.UserRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableConfigurationProperties(AppProperties.class)
 @SpringBootApplication
 public class UserServiceApplication {
+  private final UserRepository users;
+  private final AppProperties props;
+  private final PasswordEncoder encoder;
+  private final UserEventsProducer producer;
+
+  public UserServiceApplication(UserRepository users, AppProperties props, PasswordEncoder encoder, UserEventsProducer producer) {
+    this.users = users;
+    this.props = props;
+    this.encoder = encoder;
+    this.producer = producer;
+  }
 
   public static void main(String[] args) {
     SpringApplication.run(UserServiceApplication.class, args);
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void addAdminUser() {
+    if (users.findByUsername("admin").isPresent()) {
+      return;
+    }
+
+    User user = User.builder()
+        .publicId(UlidCreator.getUlid().toString())
+        .username("admin")
+        .email("admin@example.com")
+        .firstName("admin_first")
+        .lastName("admin_last")
+        .roles("ROLE_USER,ROLE_ADMIN")
+        .isEmailVerified(true)
+        .isActive(true)
+        .phoneNumber("123456789")
+        .password(encoder.encode(props.admin().password()))
+        .build();
+
+    user = users.save(user);
+
+    var USER_CREATED = props.rabbit().routingKey().userCreated();
+    producer.send(
+        new RabbitMessage<>(
+            USER_CREATED, "event",
+            new UserData(user.getId(), user.getPublicId(), user.getRoles())
+        ), USER_CREATED);
   }
 
 }

--- a/user-service/src/main/java/org/protu/userservice/config/AppProperties.java
+++ b/user-service/src/main/java/org/protu/userservice/config/AppProperties.java
@@ -6,7 +6,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 @ConfigurationProperties(prefix = "app")
-public record AppProperties(Api api, JWT jwt, Otp otp, Cloudinary cloudinary, Rabbit rabbit) {
+public record AppProperties(Api api, JWT jwt, Otp otp, Cloudinary cloudinary, Rabbit rabbit, Admin admin) {
 
   public record Api(@NotBlank String version) {
   }
@@ -52,5 +52,9 @@ public record AppProperties(Api api, JWT jwt, Otp otp, Cloudinary cloudinary, Ra
         @NotBlank String userDeleted,
         @NotBlank String userPattern) {
     }
+  }
+  
+  public record Admin(
+      @NotBlank String password) {
   }
 }

--- a/user-service/src/main/java/org/protu/userservice/producer/UserEventsProducer.java
+++ b/user-service/src/main/java/org/protu/userservice/producer/UserEventsProducer.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.protu.userservice.config.AppProperties;
 import org.protu.userservice.dto.rabbitmq.RabbitMessage;
 import org.protu.userservice.dto.rabbitmq.UserData;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,10 @@ public class UserEventsProducer {
 
   public void send(RabbitMessage<UserData> rabbitMessage, String routingKey) {
     final String USER_EVENTS_EXCHANGE = props.rabbit().exchange().userEvents();
-    rabbitTemplate.convertAndSend(USER_EVENTS_EXCHANGE, routingKey, rabbitMessage);
+    rabbitTemplate.convertAndSend(USER_EVENTS_EXCHANGE, routingKey, rabbitMessage
+        , message -> {
+          message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
+          return message;
+        });
   }
 }

--- a/user-service/src/main/resources/application-docker.yaml
+++ b/user-service/src/main/resources/application-docker.yaml
@@ -16,6 +16,9 @@ app:
     api-key: ${CLOUDINARY_API_KEY}
     api-secret: ${CLOUDINARY_API_SECRET}
 
+  admin:
+    password: ${ADMIN_PASSWORD}
+
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL}


### PR DESCRIPTION
- add admin user on `user-service` startup by subscribing to `ApplicationReadyEvent` from spring.
- externalize the admin password to an env variable.
- change the delivery mode for user events to PERSISTENT to be consumed at anytime on `content-service` startup.